### PR TITLE
Append space to self-contained completion results

### DIFF
--- a/PSReadLine/Completion.cs
+++ b/PSReadLine/Completion.cs
@@ -372,9 +372,15 @@ namespace Microsoft.PowerShell
         {
             var replacementText = completionResult.CompletionText;
             int cursorAdjustment = 0;
+            CompletionResultType[] selfContainedCompletionResultTypes = {CompletionResultType.Command,
+                CompletionResultType.Keyword, CompletionResultType.ParameterName, CompletionResultType.ProviderItem};
+
             if (completionResult.ResultType == CompletionResultType.ProviderContainer)
             {
                 replacementText = GetReplacementTextForDirectory(replacementText, ref cursorAdjustment);
+            } else if (selfContainedCompletionResultTypes.Contains(completionResult.ResultType))
+            {
+                replacementText += " ";
             }
             Replace(completions.ReplacementIndex, completions.ReplacementLength, replacementText);
             if (cursorAdjustment != 0)


### PR DESCRIPTION
Some completion result types can be reliably assumed to be the end
of an input chunk and followed by a space, so insert that space
automatically if appropriate.

eg a ProviderItem is unlikely to have anything except a space
following it, as it is the end of a path, so insert the space with
the path.

Implements #740, which has more details on the idea.

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Checklist

- [ ] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [ ] Summarized changes
- [ ] Make sure you've added one or more new tests
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->
